### PR TITLE
Import timedelta for leaderboard cache cleanup

### DIFF
--- a/apps/backend/repositories/leaderboard_repo.py
+++ b/apps/backend/repositories/leaderboard_repo.py
@@ -1,6 +1,6 @@
 """Repository for leaderboard cache operations."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 from sqlalchemy.orm import Session


### PR DESCRIPTION
## Summary
- add missing timedelta import so leaderboard cache cleanup can compute cutoff times

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901f0b36cb883209068395ef0b04812