### PR TITLE
Add streamlit option menu dependency for frontend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     # Visualization
     "plotly>=5.17.0",
     "altair>=5.1.0",
+    "streamlit-option-menu>=0.3.6",
     
     # Utilities
     "python-multipart>=0.0.6",


### PR DESCRIPTION
## Summary
- add the streamlit-option-menu package to the project dependencies so the frontend can use it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69033414d9788320818d89a44bff3637