### PR TITLE
add new feature: chat for browser

### DIFF
--- a/apps/core/schemas.py
+++ b/apps/core/schemas.py
@@ -68,6 +68,25 @@ class LeaderboardResponse(BaseModel):
         return sorted(v, key=lambda x: x.score, reverse=True)
 
 
+class LeaderboardSuggestionRequest(BaseModel):
+    """Request payload for leaderboard filter suggestions."""
+    
+    query: str = Field(..., description="User query describing desired leaderboard focus")
+
+
+class LeaderboardSuggestionResponse(BaseModel):
+    """Suggested filters derived from natural language query."""
+    
+    query: str
+    language: Optional[str] = None
+    subject_type: Optional[str] = None
+    task_type: Optional[str] = None
+    subject_type_options: List[str] = Field(default_factory=list)
+    plan_summary: str
+    used_planner: bool = False
+    metadata: Optional[Dict[str, Any]] = None
+
+
 class TaskStatus(BaseModel):
     """Task status information."""
     


### PR DESCRIPTION
## Summary

- add planner-backed leaderboard suggestion endpoint with safe defaults 
(apps/backend/services/orchestrator.py (line 302), apps/backend/routes/leaderboard.py (line 84))
- extend shared schemas for suggestion request/response payloads (apps/core/schemas.py (line 80))
- refresh Streamlit Browse tab with chat assistant, auto-load, and synced filters (apps/frontend/streamlit_app.py (line 379))
- cover planner, fallback, and empty-query cases with new unit tests (tests/unit/test_orchestrator_async.py (line 126))