### PR TITLE
Align leaderboard categories with BenchHub spec

### DIFF
--- a/apps/worker/hret_mapper.py
+++ b/apps/worker/hret_mapper.py
@@ -109,6 +109,10 @@ class HRETResultMapper:
         
         # Extract metrics from HRET result
         metrics = self._extract_metrics_from_hret_result(hret_result)
+        filters = dataset_info.get("filters", {}) if isinstance(dataset_info, dict) else {}
+        benchhub_language = filters.get("language") or dataset_info.get("language")
+        benchhub_subject_type = filters.get("subject_type") or dataset_info.get("subject_type")
+        benchhub_task_type = filters.get("task_type") or dataset_info.get("task_type")
         
         # Create model result
         model_result = BenchhubModelResult(
@@ -123,6 +127,10 @@ class HRETResultMapper:
                 "model_type": model_info.get("model_type"),
                 "dataset_name": dataset_info.get("name"),
                 "dataset_split": dataset_info.get("split"),
+                "benchhub_filters": filters,
+                "benchhub_language": benchhub_language,
+                "benchhub_subject_type": benchhub_subject_type,
+                "benchhub_task_type": benchhub_task_type,
                 "hret_metrics": metrics,
                 "evaluation_timestamp": datetime.utcnow().isoformat()
             }


### PR DESCRIPTION
## What happened?

During testing, it was confirmed that category mapping for natural language queries is not being performed correctly. ㅠㅠ

## Changes

apps/backend/services/orchestrator.py (lines 173-427) adds a subject-category normalizer, uses the most specific BenchHub label for cache lookups, and writes every coarse/fine category separately so browse filters can match stored entries.  

apps/worker/hret_mapper.py (lines 110-137) now carries the original BenchHub language/subject/task metadata into each model result, giving the storage layer authoritative categories instead of heuristics.  

apps/worker/hret_storage.py (lines 24-353) imports the BenchHub category tables, normalizes metadata before writing cache rows, and only falls back to a curated mapping that still emits valid BenchHub labels.

## Testing

python3 -m py_compile apps/backend/services/orchestrator.py apps/worker/hret_mapper.py apps/worker/hret_storage.py 

python3 -m pytest 