### PR TITLE
fix: Redis connection and health check datetime serialization errors

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,6 +41,7 @@ services:
     container_name: benchhub_backend_dev
     environment:
       - DATABASE_URL=postgresql://benchhub:dev_password@postgres:5432/benchhub_plus_dev
+      - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - OPENAI_API_KEY=${OPENAI_API_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     container_name: benchhub_backend
     environment:
       - DATABASE_URL=postgresql://benchhub:${POSTGRES_PASSWORD:-benchhub_password}@postgres:5432/benchhub_plus
+      - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - OPENAI_API_KEY=${OPENAI_API_KEY}


### PR DESCRIPTION
## Problem
Backend startup fails with Redis connection and datetime serialization errors.

## Changes
1. Missing REDIS_URL environment variable
   - Backend requires direct Redis connection for rate limiting
   - Add REDIS_URL=redis://redis:6379/0 to both docker-compose files
   - Without this, backend falls back to localhost:6379 causing connection error

2. Health check datetime serialization error
   - HealthResponse.timestamp (datetime) cannot be serialized by JSONResponse
   - Return Pydantic model directly for automatic datetime conversion
   - Add Response parameter for dynamic status codes

## Fixes:
- redis.exceptions.ConnectionError: Connection refused (localhost:6379)
- TypeError: Object of type datetime is not JSON serializable

## Testing
```
docker-compose -f docker-compose.dev.yml up -d --build
curl http://localhost:8001/api/v1/health
```