### PR TITLE
fix: UI sample_size ignored due to Planner LLM default override

### DIFF
--- a/apps/backend/services/orchestrator.py
+++ b/apps/backend/services/orchestrator.py
@@ -6,6 +6,8 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+import yaml
+
 from sqlalchemy.orm import Session
 
 from ...core.credential_service import CredentialService, StoredCredential
@@ -67,6 +69,9 @@ class EvaluationOrchestrator:
             if self.planner_agent:
                 plan_metadata = self.planner_agent.create_evaluation_plan(
                     query.query, secure_models
+                )
+                plan_metadata = self._apply_user_sample_size(
+                    plan_metadata, query.sample_size
                 )
                 plan_metadata = self._attach_credential_references(
                     plan_metadata,
@@ -407,6 +412,26 @@ class EvaluationOrchestrator:
             generated_at=datetime.utcnow(),
             total_models=len(leaderboard_entries)
         )
+
+    @staticmethod
+    def _apply_user_sample_size(
+        plan_metadata: Dict[str, Any], sample_size: int
+    ) -> Dict[str, Any]:
+        if plan_metadata.get("config"):
+            plan_metadata["config"]["sample_size"] = sample_size
+
+        plan_yaml_raw = plan_metadata.get("plan_yaml", "")
+        if plan_yaml_raw:
+            plan_dict = yaml.safe_load(plan_yaml_raw)
+            if plan_dict.get("metadata"):
+                plan_dict["metadata"]["sample_size"] = sample_size
+            for ds in plan_dict.get("datasets", []):
+                ds["sample_size"] = sample_size
+            plan_metadata["plan_yaml"] = yaml.dump(
+                plan_dict, default_flow_style=False, allow_unicode=True
+            )
+
+        return plan_metadata
 
     def _default_plan_config(self) -> PlanConfig:
         """Create a safe default plan configuration."""


### PR DESCRIPTION
## Summary
- Fixed a bug where the custom sample size set in the UI was always overridden by the Planner LLM's default value (100)
- The orchestrator now explicitly overrides `sample_size` in both `plan_metadata.config` and `plan_yaml` with the user's actual selection after receiving the planner response

## Root Cause
In `generate_leaderboard()`, only `query.query` (the text string) was passed to `planner_agent.create_evaluation_plan()`. The user's `query.sample_size` (derived from the UI's sample_scale setting) was never forwarded. Since the Planner LLM prompt defaults to `sample_size: 100`, the UI setting was silently ignored.

## Before / After

### Before — Custom(10) set but 100 samples evaluated
<img width="2314" height="816" alt="image" src="https://github.com/user-attachments/assets/1afbbd8d-9018-4ec2-89fa-0bd515206cd5" />

### After — Custom(7) set and 7 samples evaluated correctly
<img width="1150" height="404" alt="image" src="https://github.com/user-attachments/assets/98add572-d4b2-4233-98e9-be1433f96c5a" />
